### PR TITLE
fixing some url issues in endorsement pages

### DIFF
--- a/src/_includes/split.njk
+++ b/src/_includes/split.njk
@@ -19,7 +19,7 @@
                 <section class="split">
                     <img src="/assets/images/endorsement_sm_2025-10-06.png" alt="endorsements">
                     <section>
-                        {{ content | urlize | safe }}
+                        {{ content | safe }}
                     </section>
                 </section>
             </section>

--- a/src/projects/endorsements.md
+++ b/src/projects/endorsements.md
@@ -14,15 +14,18 @@ So for every folder in the drive is a few things:
 1. 1: A PDF of the questionnaire and the responses summarized
 2. 2: The full interview audio
 3. 3: A fully split interview audio labeled in order of the questionnaire
-</br>
-</br>
+<br/>
+<br/>
 
 The following links can be used to sign up for each of the prospective candidates volunteer list:
--   Newman Abuissa: https://www.newmanforiowacity.com/volunteer
--   Clara Reynen: https://www.claraforiowacity.com/get-involved
--   Katie Freeman: https://freeman4coralville.com/
+<br/>
+Newman Abuissa: [here](https://www.newmanforiowacity.com/volunteer)
+<br/>
+Clara Reynen: [here](https://www.claraforiowacity.com/get-involved)
+<br/>
+Katie Freeman: [here](https://freeman4coralville.com/)
 
-<br>
+<br/>
 We hope you find this information useful for voting and for energizing your participation in the electoral process. 
 
 There’s a lot of work left to be done, and every little contribution helps.


### PR DESCRIPTION
Noticed an issue with the URLs that included the </li> tag in the final product. Wanted to change it in a way that was more difficult to be sent incorrectly.